### PR TITLE
#16 [FEAT] APPS 부원 소개 섹션 헤더 및 설명 추가

### DIFF
--- a/src/pages/AboutAppsPage/AboutAppsPage.jsx
+++ b/src/pages/AboutAppsPage/AboutAppsPage.jsx
@@ -23,6 +23,16 @@ export default function AboutAppsPage() {
         <S.IntroToActLine></S.IntroToActLine>
       </S.Container>
       {/* 지민 */}
+      <S.TeamContainer>
+        <S.TeamIntroWrapper>
+          <S.TeamIntroTitle>APPS와 함께하는 사람들</S.TeamIntroTitle>
+          <S.TeamIntroContent>
+            APPS 동아리 내 동아리 부원들을 소개할게요
+            <br />
+            카드를 클릭하여 APPS 부원들의 인터뷰를 만나보세요!
+          </S.TeamIntroContent>
+        </S.TeamIntroWrapper>
+      </S.TeamContainer>
     </S.Root>
   );
 }

--- a/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
+++ b/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
@@ -82,3 +82,37 @@ export const IntroToActLine = styled.div`
   background-position: center;
   background-repeat: no-repeat;
 `;
+
+export const TeamContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`;
+
+export const TeamIntroWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  margin-top: 140px;
+`;
+
+export const TeamIntroTitle = styled.h2`
+  color: #fff;
+  text-align: center;
+  font-family: Pretendard;
+  font-size: 32px;
+  font-weight: 700;
+  letter-spacing: -1.6px;
+  margin: 0;
+`;
+
+export const TeamIntroContent = styled.p`
+  color: #c7c7c7;
+  text-align: center;
+  font-family: Pretendard;
+  font-size: 20px;
+  font-weight: 500;
+  letter-spacing: -1px;
+  margin: 0;
+`;

--- a/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
+++ b/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
@@ -97,10 +97,9 @@ export const TeamIntroWrapper = styled.div`
   margin-top: 140px;
 `;
 
-export const TeamIntroTitle = styled.h2`
+export const TeamIntroTitle = styled.h1`
   color: #fff;
   text-align: center;
-  font-family: Pretendard;
   font-size: 32px;
   font-weight: 700;
   letter-spacing: -1.6px;
@@ -110,7 +109,6 @@ export const TeamIntroTitle = styled.h2`
 export const TeamIntroContent = styled.p`
   color: #c7c7c7;
   text-align: center;
-  font-family: Pretendard;
   font-size: 20px;
   font-weight: 500;
   letter-spacing: -1px;


### PR DESCRIPTION


## 🚀 작업 내용

- APPS 부원 소개 섹션 헤더 및 설명 추가

<br />

## 📸 스크린샷

|    APPS 부원 소개 섹션 헤더 및 설명    |
| :----------------------: |
| <img width='600' src='https://github.com/user-attachments/assets/748b7b41-2a39-45f9-8ad3-03824a5e3494'> |

<br />

<!-- (선택)
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
