### PR TITLE
#19 [FEAT] About 페이지에서 MemberCard 컴포넌트 23개를 map 함수로 생성

### DIFF
--- a/src/components/MemberCard.jsx
+++ b/src/components/MemberCard.jsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import * as S from './MemberCard.style';
 
-export default function MemberCard({ image, name, title, position }) {
+export default function MemberCard({
+  image,
+  name,
+  title,
+  position,
+  backgroundColor,
+}) {
   return (
-    <S.MemberCard>
+    <S.MemberCard backgroundColor={backgroundColor}>
       <S.MemberImage src={image} alt={`${name} 프로필 이미지`} />
       <S.NameAndPositionWrapper>
         <S.MemberName>{name}</S.MemberName>

--- a/src/components/MemberCard.style.jsx
+++ b/src/components/MemberCard.style.jsx
@@ -1,14 +1,20 @@
 import styled from 'styled-components';
 
 export const MemberCard = styled.div`
+  position: relative;
   width: 220px;
   height: 254px;
+  flex-shrink: 0;
   border-radius: 18px;
-  background: #2051ff;
+  background-color: ${(props) => props.backgroundColor || '#2051ff'};
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-bottom: 56px;
+  justify-content: center;
+  cursor: pointer;
+  &: hover {
+    background-color: #ff5400;
+  }
 `;
 
 export const MemberImage = styled.img`

--- a/src/pages/AboutAppsPage/AboutAppsPage.jsx
+++ b/src/pages/AboutAppsPage/AboutAppsPage.jsx
@@ -1,8 +1,150 @@
 import * as S from './AboutAppsPage.style';
 import ActivityCard from '../../components/ActivityCard/ActivityCard';
 import { activitiesArr } from '../../database/activity_list';
+import MemberCard from '../../components/MemberCard';
 
 export default function AboutAppsPage() {
+  const members = [
+    {
+      name: '경민서',
+      title: '컴퓨터과학 21',
+      position: '회장',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '정지원',
+      title: '컴퓨터과학 21',
+      position: '부회장',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '류미성',
+      title: '컴퓨터과학 21',
+      position: '프론트엔드장',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '주아정',
+      title: '컴퓨터과학 21',
+      position: '백엔드장',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '윤현서',
+      title: '컴퓨터과학 21',
+      position: '10기',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '이지은',
+      title: '컴퓨터과학 21',
+      position: '10기',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '이해림',
+      title: '컴퓨터과학 21',
+      position: '10기',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '정서연',
+      title: '컴퓨터과학 21',
+      position: '10기',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '김혜림',
+      title: '컴퓨터과학 21',
+      position: '10.5기',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '하예영',
+      title: '컴퓨터과학 21',
+      position: '10.5기',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '권유진',
+      title: '컴퓨터과학 21',
+      position: '11기',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '김준희',
+      title: '컴퓨터과학 21',
+      position: '11기',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '김지민',
+      title: '컴퓨터과학 21',
+      position: '11기',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '방지희',
+      title: '컴퓨터과학 21',
+      position: '11기',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '백수민',
+      title: '컴퓨터과학 21',
+      position: '11기',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '신정은',
+      title: '컴퓨터과학 21',
+      position: '11기',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '유하연',
+      title: '컴퓨터과학 21',
+      position: '11기',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '윤서빈',
+      title: '컴퓨터과학 21',
+      position: '11기',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '윤정란',
+      title: '컴퓨터과학 21',
+      position: '11기',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '윤지원',
+      title: '컴퓨터과학 21',
+      position: '11기',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '이다빈',
+      title: '컴퓨터과학 21',
+      position: '11기',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '하지민',
+      title: '컴퓨터과학 21',
+      position: '11기',
+      image: 'ryumisung.png',
+    },
+    {
+      name: '홍연주',
+      title: '컴퓨터과학 21',
+      position: '11기',
+      image: 'ryumisung.png',
+    },
+  ];
+
   return (
     <S.Root>
       <S.TopToIntroContainer>
@@ -54,6 +196,25 @@ export default function AboutAppsPage() {
             카드를 클릭하여 APPS 부원들의 인터뷰를 만나보세요!
           </S.TeamIntroContent>
         </S.TeamIntroWrapper>
+        <S.MemberList>
+          {members.map((member, index) => (
+            <MemberCard
+              key={index}
+              image={require(`../../images/memberProfiles/${member.image}`)}
+              name={member.name}
+              title={member.title}
+              position={member.position}
+              backgroundColor={
+                index % 8 === 0 ||
+                index % 8 === 3 ||
+                index % 8 === 5 ||
+                index % 8 === 6
+                  ? '#2051FF'
+                  : '#3F69FF'
+              }
+            />
+          ))}
+        </S.MemberList>
       </S.TeamContainer>
     </S.Root>
   );

--- a/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
+++ b/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
@@ -35,6 +35,7 @@ export const PageTitleWrapper = styled.div`
   position: absolute;
   z-index: 2;
 `;
+
 export const PageTitle = styled.h1`
   color: #fff;
   font-size: 65px;
@@ -42,6 +43,7 @@ export const PageTitle = styled.h1`
   letter-spacing: -3.25px;
   margin: -6px 8.8px;
 `;
+
 export const IconTitle = styled.div`
   width: 136px;
   height: 94px;
@@ -155,4 +157,22 @@ export const TeamIntroContent = styled.p`
   font-weight: 500;
   letter-spacing: -1px;
   margin: 0;
+`;
+
+export const MemberList = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 56px 0;
+  max-width: 880px;
+  margin: 0 auto;
+  margin-top: 32px;
+  & > div:nth-child(even) {
+    margin-top: 32px;
+  }
+`;
+
+export const MemberWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  padding: 0;
 `;


### PR DESCRIPTION
## 📬 관련 이슈

close #19 

<br />

## 🚀 작업 내용

- About 페이지에서 MemberCard 컴포넌트 23개를 map 함수로 생성
- 레이아웃 및 배경색 로직 추가
- MemberCard, MemberList, MemberWrapper 스타일 설정


<br />

## 📸 스크린샷

|    About 페이지 MemberCard 레이아웃     |
| :----------------------: |
| <img width='600' src='https://github.com/user-attachments/assets/c95bd638-582f-41ce-9960-aa749896d89d'> |

<br />

<!-- (선택)
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
