### PR TITLE
#44 [Feat] About 페이지 상단 구현

### DIFF
--- a/src/database/activitiesCardList.js
+++ b/src/database/activitiesCardList.js
@@ -1,0 +1,49 @@
+export const ACTIVITIES_CARD_LIST = [
+  {
+    name: '기초 스터디',
+    intro:
+      '신입부원의 경우, 8주간의 기초 스터디를 진행합니다.\n협업의 기반이 되는 Github 사용 방법부터 웹 개발의 기초 지식인 HTML, CSS, JavaScript를 학습합니다.\n매주 주어지는 과제를 수행하면 멘토가 피드백을 제공하며, 이를 통해 개발 기초를 체계적으로 쌓을 수 있도록 돕습니다.',
+    img: './images/activities/about_basicstudy.jpg',
+  },
+  {
+    name: '일반 스터디',
+    intro:
+      '공통 관심 분야를 중심으로 스터디를 자유롭게 개설하여, 매주 일정 분량의 강의나 책 등 자료를 통해 학습합니다.\n이후 각자 배운 내용을 활용하는 과제를 수행하며 팀별 모임을 갖고, 매주 정기 세미나에서 스터디원이 돌아가며 스터디 내용을 발표합니다.\n2024년에는 React, Node.js, Spring, Java, iOS 등의 스터디가 운영되었습니다.',
+    img: './images/activities/about_normalstudy.jpg',
+  },
+  {
+    name: 'DevTalk',
+    intro:
+      '매주 세미나 시간에 개발과 관련된 다양한 주제의 DevTalk 발표를 진행합니다.\n개발 관련 지식과 경험, 대외활동, 수상 경험 등을 공유하며 함께 성장할 수 있는 기회를 만듭니다.',
+    img: './images/activities/about_DevTalk.jpg',
+  },
+  {
+    name: '친목활동-소풍',
+    intro:
+      'MT, 신입부원 환영회, 소풍, 연말 회고회 등 부원들 간 친목을 쌓을 수 있는 다양한 기회를 제공합니다.\n서로 다른 기수간 같은 꿈을 향해 도전하는 부원과 서로 돕고 응원하는 앱스를 만들어갑니다.',
+    img: './images/activities/about_picnic.jpg',
+  },
+  {
+    name: '친목활동-MT',
+    intro:
+      'MT, 신입부원 환영회, 소풍, 연말 회고회 등 부원들 간 친목을 쌓을 수 있는 다양한 기회를 제공합니다.\n서로 다른 기수간 같은 꿈을 향해 도전하는 부원과 서로 돕고 응원하는 앱스를 만들어갑니다.',
+    img: './images/activities/about_MT.jpg',
+  },
+  {
+    name: '신입부원 프로젝트',
+    intro:
+      '연말 전시회를 목표로 신입부원 프로젝트를 진행합니다.\n기초 스터디를 마친 후, 아이디어를 구상하고 개발에 들어갑니다.\n중간 점검을 통해 여러 차례 피드백을 받은 뒤, 최종 결과물을 연말 전시회에 출품합니다.',
+    img: './images/activities/about_BSproject.jpg',
+  },
+  {
+    name: '팀 프로젝트',
+    intro:
+      '연말 전시회를 목표로 팀 프로젝트를 진행합니다.\n3월에 프로젝트 아이디어 공모가 이루어지며, 이후 팀원 모집 기간을 갖습니다.\n모집이 완료되면 아이디어 개발, 와이어프레임 제작, 그리고 개발 과정을 거쳐 최종 결과물을 연말 전시회에 출품합니다.',
+    img: './images/activities/about_teamproject.jpg',
+  },
+  {
+    name: '오프라인 전시회',
+    intro: '한 해 동안 진행한 프로젝트들을 한자리에 모아 전시하는 행사입니다.',
+    img: './images/activities/about_exhibition.jpg',
+  },
+];

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -6,3 +6,4 @@ export * from './MonthlyActivityList';
 export * from './projectCategoryList';
 export * from './projectList';
 export * from './socialMediaLinkCards';
+export * from './styledSquareColorCards';

--- a/src/database/styledSquareColorCards.js
+++ b/src/database/styledSquareColorCards.js
@@ -1,0 +1,39 @@
+export const STYLED_SQUARE_COLOR_CARDS = [
+  [['#043bff'], ['var(--blue2, #2051FF)', null]],
+  [
+    ['var(--blue2, #2051FF)', '#043bff', null, null, 'var(--blue2, #2051FF)'],
+    ['#043bff', 'var(--blue2, #2051FF)', null],
+  ],
+  [
+    [
+      null,
+      'var(--blue2, #2051FF)',
+      'var(--blue2, #2051FF)',
+      'var(--blue2, #2051FF)',
+      null,
+      '#FF5400',
+    ],
+    ['var(--blue2, #2051FF)', 'var(--blue2, #2051FF)', null, null, '#043bff'],
+  ],
+  [
+    [
+      null,
+      null,
+      '#043bff',
+      'var(--blue2, #2051FF)',
+      null,
+      null,
+      'var(--blue2, #2051FF)',
+      '#FF5400',
+    ],
+    [
+      '#FF5400',
+      null,
+      'var(--blue2, #2051FF)',
+      null,
+      null,
+      'var(--blue2, #2051FF)',
+    ],
+  ],
+  [[null, 'square2', null, null, 'var(--blue2, #2051FF)'], ['square2']],
+];

--- a/src/pages/AboutAppsPage/AboutAppsPage.jsx
+++ b/src/pages/AboutAppsPage/AboutAppsPage.jsx
@@ -1,6 +1,11 @@
 import { useState } from 'react';
 import * as S from './AboutAppsPage.style';
-import { MEMBERS, ACTIVITY_LIST, MONTHLY_ACTIVITY_LIST } from '../../database';
+import {
+  MEMBERS,
+  ACTIVITY_LIST,
+  MONTHLY_ACTIVITY_LIST,
+  STYLED_SQUARE_COLOR_CARDS,
+} from '../../database';
 import {
   MemberCard,
   Modal,
@@ -35,6 +40,31 @@ export default function AboutAppsPage() {
               <S.PageTitle>ABOUT</S.PageTitle>
               <S.IconTitle></S.IconTitle>
             </S.PageTitleWrapper>
+            <S.SquareContainer>
+              {STYLED_SQUARE_COLOR_CARDS.map((colors) => {
+                return (
+                  <S.StyledSquareWrapper>
+                    {colors.map((left) => {
+                      return (
+                        <S.StyledSquares>
+                          {left.map((c) => {
+                            return (
+                              <>
+                                {c === 'square2' ? (
+                                  <S.StyledSquare2></S.StyledSquare2>
+                                ) : (
+                                  <S.StyledSquare color={c}></S.StyledSquare>
+                                )}
+                              </>
+                            );
+                          })}
+                        </S.StyledSquares>
+                      );
+                    })}
+                  </S.StyledSquareWrapper>
+                );
+              })}
+            </S.SquareContainer>
           </S.Top>
           <S.IntroAPPSTitle>INTRODUCTION</S.IntroAPPSTitle>
           <S.IntroAPPSContent>

--- a/src/pages/AboutAppsPage/AboutAppsPage.jsx
+++ b/src/pages/AboutAppsPage/AboutAppsPage.jsx
@@ -38,6 +38,7 @@ export default function AboutAppsPage() {
           <S.Top>
             <S.PageTitleWrapper>
               <S.PageTitle>ABOUT</S.PageTitle>
+              <S.PageSubTitle>APPS 소개</S.PageSubTitle>
               <S.IconTitle></S.IconTitle>
             </S.PageTitleWrapper>
             <S.SquareContainer>

--- a/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
+++ b/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
@@ -42,6 +42,15 @@ export const PageTitle = styled.h1`
   margin: -6px 9px;
 `;
 
+export const PageSubTitle = styled.h1`
+  color: #fff;
+  font-size: 20px;
+  font-weight: 500;
+  letter-spacing: -1px;
+  position: absolute;
+  padding: 75px 0 0 117px;
+`;
+
 export const IconTitle = styled.div`
   width: 136px;
   height: 94px;

--- a/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
+++ b/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
@@ -75,7 +75,6 @@ export const StyledSquareWrapper = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  transition
 `;
 
 export const StyledSquares = styled.div`

--- a/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
+++ b/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
@@ -18,7 +18,7 @@ export const TopToIntroContainer = styled.div`
 
 export const Top = styled.div`
   width: 100%;
-  min-height: 234px;
+  height: 234px;
   background-color: #3f69ff;
   justify-content: center;
   display: flex;
@@ -49,7 +49,43 @@ export const IconTitle = styled.div`
   background-size: contain;
   background-repeat: no-repeat;
   margin-top: 5px;
-  background-color: #3f69ff;
+`;
+
+export const SquareContainer = styled.div`
+  width: 100%;
+  min-height: 234px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const StyledSquareWrapper = styled.div`
+  width: 100%;
+  max-width: 961px;
+  height: 50px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transition
+`;
+
+export const StyledSquares = styled.div`
+  display: flex;
+  height: 50px;
+`;
+
+export const StyledSquare = styled.div`
+  width: 50px;
+  height: 50px;
+  border-radius: 12px;
+  background: ${(props) => props.color || ''};
+`;
+
+export const StyledSquare2 = styled.div`
+  width: 50px;
+  height: 34px;
+  border-radius: 12px;
+  background: #2051ff;
 `;
 
 export const IntroAPPSTitle = styled.h2`


### PR DESCRIPTION
## 📬 관련 이슈

close #44

<br />

## 🚀 작업 내용

- 데이터 이름 변경
- import 방식 변경
- 헤더 구현
- 네모 부분 구현

<br />

## 📸 스크린샷

|     About 페이지 상단 구현    |
| :----------------------: |
| <img width='600' src='https://github.com/user-attachments/assets/b3af590a-522f-4175-b871-7e955338391c'> |

<br />

<!-- (선택)
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
