### PR TITLE
#68 [FEAT] Header, Footer, 홈화면 반응형 구현

### DIFF
--- a/src/components/AboutAppsCoreValueCard/AboutAppsCoreValueCard.style.jsx
+++ b/src/components/AboutAppsCoreValueCard/AboutAppsCoreValueCard.style.jsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { BREAKPOINTS } from '../../styles/mediaQueries.style';
 
 export const AboutAppsCoreValueCard = styled.div`
   display: flex;
@@ -11,6 +12,13 @@ export const ImageWrapper = styled.div`
   width: 100%;
   height: 80px;
   padding-bottom: 13px;
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    height: 60px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    height: 40px;
+  }
 `;
 
 export const Title = styled.span`
@@ -20,6 +28,13 @@ export const Title = styled.span`
   font-size: 20px;
   font-weight: 600;
   letter-spacing: -1px;
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 18px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 14px;
+  }
 `;
 
 export const Description = styled.p`
@@ -27,6 +42,7 @@ export const Description = styled.p`
   color: ${({ color }) => color};
   text-align: center;
   font-size: 14px;
+  font-weight: 500;
   letter-spacing: -0.7px;
   white-space: pre-line;
 `;

--- a/src/components/Header/Header.style.jsx
+++ b/src/components/Header/Header.style.jsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
+import { BREAKPOINTS } from '../../styles/mediaQueries.style';
 
 export const StyledLink = styled(Link)`
   text-decoration: none;
@@ -28,11 +29,26 @@ export const Logo = styled.div`
   cursor: pointer;
   padding: 22px;
   margin: 0 30px;
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    padding: 18px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    margin: 0 10px;
+    padding: 14px;
+  }
 `;
 
 export const Menu = styled.div`
   margin: 0 50px;
   text-decoration: none;
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    margin: 0 40px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    margin: 0 10px;
+  }
 `;
 
 export const MenuStyle = styled.span`
@@ -46,6 +62,13 @@ export const MenuStyle = styled.span`
   transition:
     font-weight 0.2s ease,
     color 0.2s ease;
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    padding: 18px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    padding: 14px;
+  }
 `;
 
 export const RecruitmentAlertLink = styled(MenuStyle)``;

--- a/src/components/MemberFeedbackCardList/MemberFeedbackCardList.style.jsx
+++ b/src/components/MemberFeedbackCardList/MemberFeedbackCardList.style.jsx
@@ -1,4 +1,5 @@
 import styled, { keyframes } from 'styled-components';
+import { BREAKPOINTS } from '../../styles/mediaQueries.style';
 
 const moveLeft = keyframes`
   0% {
@@ -15,8 +16,15 @@ const moveLeft = keyframes`
 export const MemberFeedbackCardList = styled.div`
   display: flex;
   position: relative;
-  gap: 40px;
   width: 100%;
+  gap: 40px;
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    gap: 30px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    gap: 20px;
+  }
 `;
 
 export const CardWrapper = styled.div`
@@ -25,8 +33,11 @@ export const CardWrapper = styled.div`
   align-items: center;
   margin-top: ${({ index }) => (index % 2 === 0 ? '' : '100px')};
   gap: 10px;
-
   animation: ${moveLeft} 5s linear infinite;
+
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    gap: 6px;
+  }
 `;
 
 export const BalloonCard = styled.div`
@@ -36,7 +47,11 @@ export const BalloonCard = styled.div`
   background: #fff;
   padding: 20px;
   min-width: 220px;
-  /* width: 300px; */
+
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    min-width: 180px;
+    padding: 14px;
+  }
 `;
 
 export const BalloonCardContentBody = styled.div`
@@ -53,6 +68,10 @@ export const BalloonCardContent = styled.p`
   font-weight: 500;
   letter-spacing: -0.9px;
   word-break: keep-all;
+
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 14px;
+  }
 `;
 
 export const BalloonCardReviewMember = styled.span`
@@ -60,6 +79,10 @@ export const BalloonCardReviewMember = styled.span`
   font-size: 14px;
   font-weight: 500;
   letter-spacing: -0.7px;
+
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 12px;
+  }
 `;
 
 export const BalloonTail = styled.div`
@@ -70,6 +93,10 @@ export const BalloonTail = styled.div`
   height: 20px;
   background: #fff;
   clip-path: polygon(50% 100%, 0% 0%, 100% 0%);
+
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    width: 24px;
+  }
 `;
 
 export const Character = styled.div`
@@ -80,7 +107,15 @@ export const Character = styled.div`
   padding: 20px;
   box-sizing: border-box;
 
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    padding: 14px;
+  }
+
   img {
     height: 120px;
+
+    @media (max-width: ${BREAKPOINTS[0]}px) {
+      height: 100px;
+    }
   }
 `;

--- a/src/components/ProjectCardList/ProjectCardList.style.jsx
+++ b/src/components/ProjectCardList/ProjectCardList.style.jsx
@@ -1,9 +1,17 @@
 import styled from 'styled-components';
+import { BREAKPOINTS } from '../../styles/mediaQueries.style';
 
 export const ProjectCardList = styled.div`
   display: flex;
   flex-direction: column;
   gap: 60px;
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    gap: 40px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    gap: 20px;
+  }
 `;
 
 export const TabBar = styled.div`
@@ -15,10 +23,13 @@ export const TabBar = styled.div`
 `;
 
 export const Tab = styled.div`
-  background: ${(props) => (props.isActive ? '#ff88fb' : '#333')};
+  display: flex;
+  justify-content: center;
+  background: ${(props) => (props.isActive ? '#ff88fb' : '')};
   margin: 5px;
   border-radius: 30px;
-  padding: 12px 78px;
+  padding: 12px;
+  width: 100%;
   color: #fff;
   font-size: 20px;
   font-weight: 500;
@@ -29,6 +40,16 @@ export const Tab = styled.div`
 
   &:hover {
     background-color: #ff88fb;
+  }
+
+  @media (max-width: ${BREAKPOINTS[2]}px) {
+  }
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 18px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    padding: 8px;
+    font-size: 16px;
   }
 `;
 

--- a/src/components/SocialMediaLinkCards/SocialMediaLinkCards.style.jsx
+++ b/src/components/SocialMediaLinkCards/SocialMediaLinkCards.style.jsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
+import { BREAKPOINTS } from '../../styles/mediaQueries.style';
 
 export const StyledLink = styled(Link)`
   text-decoration: none;
@@ -26,6 +27,10 @@ export const SocialLinksCardTitle = styled.span`
   font-size: 18px;
   font-weight: 500;
   letter-spacing: -0.9px;
+
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 14px;
+  }
 `;
 
 export const SocialLinksCardAccount = styled.span`
@@ -34,4 +39,8 @@ export const SocialLinksCardAccount = styled.span`
   font-size: 18px;
   font-weight: 500;
   letter-spacing: -0.9px;
+
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 14px;
+  }
 `;

--- a/src/components/SocialMediaLinkCards/SocialMediaLinkCards.style.jsx
+++ b/src/components/SocialMediaLinkCards/SocialMediaLinkCards.style.jsx
@@ -14,7 +14,17 @@ export const SocialLinksCard = styled.div`
   gap: 18px;
 `;
 
-export const SocialLinksCardImage = styled.div``;
+export const SocialLinksCardImage = styled.div`
+  display: flex;
+  height: 90px;
+
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    height: 80px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    height: 60px;
+  }
+`;
 
 export const SocialLinksCardDescription = styled.div`
   display: flex;

--- a/src/database/MonthlyActivityList.js
+++ b/src/database/MonthlyActivityList.js
@@ -14,7 +14,7 @@ export const MONTHLY_ACTIVITY_LIST = [
     schedule: [
       '2024 프로젝트 팀 빌딩',
       '기초 스터디 - JavaScript',
-      'Microsoft Power Auto-mate로 업무 자동화하기” 핸즈온 세션 참가',
+      "'Microsoft Power Auto-mate로 업무 자동화하기' 핸즈온 세션 참가",
     ],
   },
   {

--- a/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
+++ b/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
@@ -197,7 +197,7 @@ export const CalendarDescription = styled.div`
   font-size: 20px;
   font-weight: 500;
   letter-spacing: -1px;
-  margin: 0 0 108px 0;
+  margin-bottom: 40px;
 `;
 
 export const CalendarCardWrapper = styled.div`
@@ -304,7 +304,7 @@ export const MemberList = styled.div`
   gap: 56px 0;
   max-width: 880px;
   margin: 0 auto;
-  margin-top: 32px;
+  margin-top: 40px;
   & > div:nth-child(even) {
     margin-top: 32px;
   }

--- a/src/pages/HomePage/HomePage.style.jsx
+++ b/src/pages/HomePage/HomePage.style.jsx
@@ -1,5 +1,6 @@
 import styled, { keyframes } from 'styled-components';
 import { Link } from 'react-router-dom';
+import { BREAKPOINTS } from '../../styles/mediaQueries.style';
 
 export const StyledLink = styled(Link)`
   text-decoration: none;
@@ -37,6 +38,13 @@ export const HomePage = styled.div`
 export const HomeMainWrapper = styled.section`
   position: relative;
   padding: 200px 0 360px;
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    padding: 200px 0 360px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    padding: 200px 0 360px;
+  }
 `;
 
 export const TitleWrapper = styled.div`
@@ -44,6 +52,13 @@ export const TitleWrapper = styled.div`
   flex-direction: column;
   align-items: end;
   padding-right: 70px;
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    padding-right: 40px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    padding-right: 30px;
+  }
 `;
 
 export const ExhibitionTitle = styled.h3`
@@ -54,6 +69,16 @@ export const ExhibitionTitle = styled.h3`
   font-size: 65px;
   font-weight: 700;
   letter-spacing: -3.25px;
+
+  @media (max-width: ${BREAKPOINTS[2]}px) {
+    font-size: 52px;
+  }
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 40px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 28px;
+  }
 `;
 
 export const APPSTitle = styled.h1`
@@ -64,6 +89,16 @@ export const APPSTitle = styled.h1`
   font-size: 100px;
   font-weight: 700;
   letter-spacing: -5px;
+
+  @media (max-width: ${BREAKPOINTS[2]}px) {
+    font-size: 80px;
+  }
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 60px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 44px;
+  }
 `;
 
 export const APPSSubTitle = styled.span`
@@ -73,6 +108,13 @@ export const APPSSubTitle = styled.span`
   font-size: 24px;
   font-weight: 700;
   letter-spacing: -1.2px;
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 18px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 14px;
+  }
 `;
 
 export const SectionWrapper = styled.section`

--- a/src/pages/HomePage/HomePage.style.jsx
+++ b/src/pages/HomePage/HomePage.style.jsx
@@ -34,9 +34,6 @@ export const HomePage = styled.div`
   margin: 0 auto 200px;
   gap: 113px;
 
-  @media (max-width: ${BREAKPOINTS[1]}px) {
-    gap: 100px;
-  }
   @media (max-width: ${BREAKPOINTS[0]}px) {
     gap: 80px;
   }
@@ -47,10 +44,10 @@ export const HomeMainWrapper = styled.section`
   padding: 200px 0 360px;
 
   @media (max-width: ${BREAKPOINTS[1]}px) {
-    padding: 200px 0 360px;
+    padding: 200px 0 300px;
   }
   @media (max-width: ${BREAKPOINTS[0]}px) {
-    padding: 200px 0 360px;
+    padding: 200px 0 240px;
   }
 `;
 
@@ -141,9 +138,28 @@ export const SectionTitleImageWrapper = styled.div`
   display: flex;
   justify-content: center;
   gap: 16px;
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    gap: 14px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    gap: 12px;
+  }
+
+  img {
+    @media (max-width: ${BREAKPOINTS[1]}px) {
+      height: 60px;
+    }
+    @media (max-width: ${BREAKPOINTS[0]}px) {
+      height: 40px;
+    }
+  }
 `;
 
 export const SectionTitle = styled.h2`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   margin: 0;
   color: #fff;
   text-align: center;
@@ -173,7 +189,7 @@ export const SmallSectionTitle = styled(SectionTitle)`
     font-size: 32px;
   }
   @media (max-width: ${BREAKPOINTS[0]}px) {
-    font-size: 18px;
+    font-size: 24px;
   }
 `;
 
@@ -184,6 +200,7 @@ export const SectionSubTitle = styled.h4`
   font-size: 20px;
   font-weight: 500;
   letter-spacing: -1px;
+  word-break: keep-all;
 
   @media (max-width: ${BREAKPOINTS[1]}px) {
     font-size: 18px;
@@ -313,12 +330,19 @@ export const SocialLinksContent = styled.div`
     gap: 60px;
   }
   @media (max-width: ${BREAKPOINTS[0]}px) {
-    gap: 40px;
+    gap: 30px;
   }
 `;
 
 export const ProjectList = styled.section`
   padding: 0 70px;
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    padding: 0 50px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    padding: 0 10px;
+  }
 `;
 
 export const ShareLinks = styled.section`

--- a/src/pages/HomePage/HomePage.style.jsx
+++ b/src/pages/HomePage/HomePage.style.jsx
@@ -33,6 +33,13 @@ export const HomePage = styled.div`
   width: 100%;
   margin: 0 auto 200px;
   gap: 113px;
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    gap: 100px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    gap: 80px;
+  }
 `;
 
 export const HomeMainWrapper = styled.section`
@@ -190,6 +197,13 @@ export const SectionContentWrapper = styled.div`
   display: flex;
   flex-direction: column;
   padding: 0 70px;
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    padding: 0 50px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    padding: 0 20px;
+  }
 `;
 
 export const SectionContent = styled.div`
@@ -225,9 +239,14 @@ export const SectionContent = styled.div`
 
 export const SectionContentInnerBox = styled.div`
   display: flex;
-  padding: 30px 31px;
+  padding: 30px;
   gap: 60px;
   position: relative;
+
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    padding: 20px;
+    gap: 40px;
+  }
 `;
 
 export const SectionContentInnerBox1 = styled(SectionContentInnerBox)`
@@ -263,6 +282,13 @@ export const SocialLinks = styled.section`
   flex-direction: column;
   align-items: center;
   gap: 80px;
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    gap: 60px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    gap: 40px;
+  }
 `;
 
 export const SocialLinksTitle = styled.h5`
@@ -282,6 +308,13 @@ export const SocialLinksTitle = styled.h5`
 export const SocialLinksContent = styled.div`
   display: flex;
   gap: 112px;
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    gap: 60px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    gap: 40px;
+  }
 `;
 
 export const ProjectList = styled.section`
@@ -294,6 +327,13 @@ export const ShareLinks = styled.section`
   justify-content: center;
   align-content: center;
   gap: 80px;
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    gap: 60px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    gap: 40px;
+  }
 `;
 
 export const ShareLinksTitle = styled.h5`
@@ -315,13 +355,19 @@ export const ShareLinksContent = styled.div`
   display: flex;
   justify-content: center;
   gap: 70px;
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    gap: 50px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    gap: 30px;
+  }
 `;
 
 export const LinkButton = styled.button`
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  gap: 8px;
   border-radius: 30px;
   border: none;
   background: #fff;
@@ -333,6 +379,7 @@ export const LinkButton = styled.button`
   font-weight: 500;
   letter-spacing: -0.9px;
   cursor: pointer;
+  gap: 8px;
   transition:
     background 0.3s ease,
     color 0.3s ease;
@@ -340,5 +387,15 @@ export const LinkButton = styled.button`
   &:hover {
     background: var(--pink, #ff88fb);
     color: #fff;
+  }
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    width: 150px;
+    font-size: 14px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    width: 130px;
+    padding: 10px 0;
+    font-size: 14px;
   }
 `;

--- a/src/pages/HomePage/HomePage.style.jsx
+++ b/src/pages/HomePage/HomePage.style.jsx
@@ -144,10 +144,30 @@ export const SectionTitle = styled.h2`
   font-size: 65px;
   font-weight: 700;
   letter-spacing: -3.25px;
+
+  @media (max-width: ${BREAKPOINTS[2]}px) {
+    font-size: 52px;
+  }
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 40px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 28px;
+  }
 `;
 
 export const SmallSectionTitle = styled(SectionTitle)`
   font-size: 50px;
+
+  @media (max-width: ${BREAKPOINTS[2]}px) {
+    font-size: 40px;
+  }
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 32px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 18px;
+  }
 `;
 
 export const SectionSubTitle = styled.h4`
@@ -157,6 +177,13 @@ export const SectionSubTitle = styled.h4`
   font-size: 20px;
   font-weight: 500;
   letter-spacing: -1px;
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 18px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 14px;
+  }
 `;
 
 export const SectionContentWrapper = styled.div`
@@ -243,7 +270,13 @@ export const SocialLinksTitle = styled.h5`
   color: #fff;
   font-size: 32px;
   font-weight: 700;
-  /* letter-spacing: -1.6px; */
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 28px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 20px;
+  }
 `;
 
 export const SocialLinksContent = styled.div`
@@ -269,7 +302,13 @@ export const ShareLinksTitle = styled.h5`
   font-size: 32px;
   font-weight: 700;
   margin: 0;
-  /* letter-spacing: -1.6px; */
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 28px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 20px;
+  }
 `;
 
 export const ShareLinksContent = styled.div`


### PR DESCRIPTION
## 📬 관련 이슈

close #68

<br />

## 🚀 작업 내용

- Header, Footer, 홈화면 반응형 구현
- 프로젝트 항목 디자인 수정

<br />

## 📸 스크린샷

|  `프로젝트 항목` 섹션      |
| :----------------------: |
| <img width='600' src='https://github.com/user-attachments/assets/58d81458-b52a-4115-8e7e-0567151a9ae9'> |

<br />


## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?
- 반응형에 따른 배경 이미지 크기 조정은 추후에 수정
<br />

