### PR TITLE
#70 [FEAT]  About 페이지 상단, 활동, 달력 섹션 반응형 구현

### DIFF
--- a/src/components/ActivityCard/ActivityCard.style.jsx
+++ b/src/components/ActivityCard/ActivityCard.style.jsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { BREAKPOINTS } from '../../styles/mediaQueries.style';
 
 export const ActivityCard = styled.div`
   width: 470px;
@@ -9,6 +10,10 @@ export const ActivityCard = styled.div`
   background-position: 50%;
   background-size: cover;
   background-repeat: no-repeat;
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    width: 340px;
+    height: 217px;
+  }
 `;
 
 export const ActivityTextWrapper = styled.div`
@@ -16,6 +21,9 @@ export const ActivityTextWrapper = styled.div`
   position: absolute;
   width: 470px;
   justify-content: center;
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    width: 340px;
+  }
 `;
 
 export const ActivityName = styled.h2`
@@ -32,6 +40,16 @@ export const ActivityName = styled.h2`
   font-size: 20px;
   font-weight: 600;
   letter-spacing: -1px;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    margin: 30px 0 0 30px;
+    font-size: 18px;
+    padding: 10px 38px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    margin: 20px 0 0 20px;
+    font-size: 16px;
+    padding: 6px 21px;
+  }
 `;
 
 export const ActivityIntroWrapper = styled.div`
@@ -40,6 +58,12 @@ export const ActivityIntroWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: end;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    height: 184px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    height: 133px;
+  }
 `;
 
 export const ActivityIntro = styled.p`
@@ -49,6 +73,13 @@ export const ActivityIntro = styled.p`
   letter-spacing: -0.7px;
   margin: 0;
   word-break: keep-all;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 14px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    width: 300px;
+    font-size: 12px;
+  }
 `;
 
 export const ActivityBackBlur = styled.div`
@@ -63,4 +94,8 @@ export const ActivityBackBlur = styled.div`
   transition:
     background 0.3s ease,
     border 0.3s ease;
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    width: 340px;
+    height: 217px;
+  }
 `;

--- a/src/components/ActivityCard/ActivityCard.style.jsx
+++ b/src/components/ActivityCard/ActivityCard.style.jsx
@@ -10,6 +10,7 @@ export const ActivityCard = styled.div`
   background-position: 50%;
   background-size: cover;
   background-repeat: no-repeat;
+
   @media (max-width: ${BREAKPOINTS[0]}px) {
     width: 340px;
     height: 217px;
@@ -21,6 +22,7 @@ export const ActivityTextWrapper = styled.div`
   position: absolute;
   width: 470px;
   justify-content: center;
+
   @media (max-width: ${BREAKPOINTS[0]}px) {
     width: 340px;
   }
@@ -40,6 +42,7 @@ export const ActivityName = styled.h2`
   font-size: 20px;
   font-weight: 600;
   letter-spacing: -1px;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     margin: 30px 0 0 30px;
     font-size: 18px;
@@ -58,6 +61,7 @@ export const ActivityIntroWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: end;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     height: 184px;
   }
@@ -73,6 +77,7 @@ export const ActivityIntro = styled.p`
   letter-spacing: -0.7px;
   margin: 0;
   word-break: keep-all;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     font-size: 14px;
   }
@@ -94,6 +99,7 @@ export const ActivityBackBlur = styled.div`
   transition:
     background 0.3s ease,
     border 0.3s ease;
+
   @media (max-width: ${BREAKPOINTS[0]}px) {
     width: 340px;
     height: 217px;

--- a/src/components/CalendarCard/CalendarCard.style.jsx
+++ b/src/components/CalendarCard/CalendarCard.style.jsx
@@ -25,6 +25,7 @@ export const CalendarCard = styled.div`
       background 0.2s ease,
       color 0.2s ease;
   }
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     width: 198px;
     min-height: 160px;
@@ -42,6 +43,7 @@ export const CalendarMonthWrapper = styled.div`
   padding: 20px 0 0 26px;
   align-items: center;
   gap: 12px;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     padding: 18px 0 0 23px;
     gap: 10px;
@@ -59,6 +61,7 @@ export const CalendarMonthDot = styled.div`
   background-image: url('/images/icons/about_calendar_blue_dot.svg');
   background-size: contain;
   background-repeat: no-repeat;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     width: 9px;
     height: 9px;
@@ -76,6 +79,7 @@ export const CalendarMonth = styled.h3`
   font-weight: 600;
   letter-spacing: -1px;
   margin: 0;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     font-size: 18px;
   }
@@ -89,6 +93,7 @@ export const ScheduleWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     padding: 12px 18px 22px;
     gap: 9px;
@@ -113,6 +118,7 @@ export const Schedule = styled.div`
   font-weight: 600;
   letter-spacing: -0.7px;
   word-break: keep-all;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     font-size: 12px;
   }

--- a/src/components/CalendarCard/CalendarCard.style.jsx
+++ b/src/components/CalendarCard/CalendarCard.style.jsx
@@ -1,7 +1,9 @@
 import styled from 'styled-components';
+import { BREAKPOINTS } from '../../styles/mediaQueries.style';
 
 export const CalendarCard = styled.div`
   width: 220px;
+  min-height: 180px;
   border-radius: 18px;
   border: 1px solid #fff;
   transition: all 0.2s ease;
@@ -23,6 +25,16 @@ export const CalendarCard = styled.div`
       background 0.2s ease,
       color 0.2s ease;
   }
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    width: 198px;
+    min-height: 160px;
+    border-radius: 18px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    width: 178px;
+    min-height: 130px;
+    border-radius: 18px;
+  }
 `;
 
 export const CalendarMonthWrapper = styled.div`
@@ -30,6 +42,14 @@ export const CalendarMonthWrapper = styled.div`
   padding: 20px 0 0 26px;
   align-items: center;
   gap: 12px;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    padding: 18px 0 0 23px;
+    gap: 10px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    padding: 15px 0 0 20px;
+    gap: 6px;
+  }
 `;
 
 export const CalendarMonthDot = styled.div`
@@ -39,6 +59,14 @@ export const CalendarMonthDot = styled.div`
   background-image: url('/images/icons/about_calendar_blue_dot.svg');
   background-size: contain;
   background-repeat: no-repeat;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    width: 9px;
+    height: 9px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    width: 5px;
+    height: 5px;
+  }
 `;
 
 export const CalendarMonth = styled.h3`
@@ -48,6 +76,12 @@ export const CalendarMonth = styled.h3`
   font-weight: 600;
   letter-spacing: -1px;
   margin: 0;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 18px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 14px;
+  }
 `;
 
 export const ScheduleWrapper = styled.div`
@@ -55,6 +89,14 @@ export const ScheduleWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    padding: 12px 18px 22px;
+    gap: 9px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    padding: 10px 14px 17px;
+    gap: 7px;
+  }
 `;
 
 export const Schedule = styled.div`
@@ -71,4 +113,11 @@ export const Schedule = styled.div`
   font-weight: 600;
   letter-spacing: -0.7px;
   word-break: keep-all;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 12px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 10px;
+    padding: 5px 10px;
+  }
 `;

--- a/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
+++ b/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { BREAKPOINTS } from '../../styles/mediaQueries.style';
 
 export const Root = styled.div`
   width: 100%;
@@ -22,6 +23,12 @@ export const Top = styled.div`
   background-color: #3f69ff;
   justify-content: center;
   display: flex;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    height: 187px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    height: 117px;
+  }
 `;
 
 export const PageTitleWrapper = styled.div`
@@ -32,6 +39,14 @@ export const PageTitleWrapper = styled.div`
   justify-content: center;
   position: absolute;
   z-index: 2;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    margin-top: 53px;
+    height: 78px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    margin-top: 33px;
+    height: 49px;
+  }
 `;
 
 export const PageTitle = styled.h1`
@@ -40,6 +55,12 @@ export const PageTitle = styled.h1`
   font-weight: 700;
   letter-spacing: -3.2px;
   margin: -6px 9px;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 45px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 32px;
+  }
 `;
 
 export const PageSubTitle = styled.h1`
@@ -49,6 +70,14 @@ export const PageSubTitle = styled.h1`
   letter-spacing: -1px;
   position: absolute;
   padding: 75px 0 0 117px;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 18px;
+    padding: 60px 0 0 94px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 14px;
+    padding: 38px 0 0 58px;
+  }
 `;
 
 export const IconTitle = styled.div`
@@ -58,6 +87,14 @@ export const IconTitle = styled.div`
   background-size: contain;
   background-repeat: no-repeat;
   margin-top: 5px;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    width: 108px;
+    height: 75px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    width: 68px;
+    height: 47px;
+  }
 `;
 
 export const SquareContainer = styled.div`
@@ -66,6 +103,7 @@ export const SquareContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  overflow: hidden;
 `;
 
 export const StyledSquareWrapper = styled.div`
@@ -75,11 +113,26 @@ export const StyledSquareWrapper = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    height: 40px;
+    width: 1000px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    height: 25px;
+    width: 500px;
+  }
 `;
 
 export const StyledSquares = styled.div`
   display: flex;
   height: 50px;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    height: 40px;
+  }
+
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    height: 25px;
+  }
 `;
 
 export const StyledSquare = styled.div`
@@ -87,6 +140,17 @@ export const StyledSquare = styled.div`
   height: 50px;
   border-radius: 12px;
   background: ${(props) => props.color || ''};
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+  }
+
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    width: 25px;
+    height: 25px;
+    border-radius: 6px;
+  }
 `;
 
 export const StyledSquare2 = styled.div`
@@ -94,6 +158,17 @@ export const StyledSquare2 = styled.div`
   height: 34px;
   border-radius: 12px;
   background: #2051ff;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    width: 40px;
+    height: 27px;
+    border-radius: 10px;
+  }
+
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    width: 25px;
+    height: 17px;
+    border-radius: 6px;
+  }
 `;
 
 export const IntroAPPSTitle = styled.h2`
@@ -105,6 +180,14 @@ export const IntroAPPSTitle = styled.h2`
   line-height: 28px;
   letter-spacing: -1.2px;
   margin: 45px 0 31px 0;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 22px;
+    margin: 36px 0 25px 0;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 18px;
+    margin: 27px 0 15px 0;
+  }
 `;
 
 export const IntroAPPSContent = styled.p`
@@ -115,6 +198,14 @@ export const IntroAPPSContent = styled.p`
   line-height: 28px;
   letter-spacing: -1px;
   margin: 0 0 53px 0;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 18px;
+    margin: 0 0 42px 0;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 14px;
+    margin: 0 0 26px 0;
+  }
 `;
 
 export const IntroToActLine = styled.div`
@@ -125,6 +216,12 @@ export const IntroToActLine = styled.div`
   background-size: 962px 2px;
   background-position: center;
   background-repeat: no-repeat;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    background-size: 600px 1px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    background-size: 380px 1px;
+  }
 `;
 
 export const ActivitiesContainer = styled.div`
@@ -139,6 +236,12 @@ export const ActivitiesTitleWrapper = styled.div`
   justify-content: center;
   margin-top: 113px;
   gap: 16px;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    margin-top: 90px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    margin-top: 56px;
+  }
 `;
 
 export const ActivitiesTitle = styled.div`
@@ -149,6 +252,13 @@ export const ActivitiesTitle = styled.div`
   font-weight: 700;
   line-height: 28px;
   letter-spacing: -2px;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 32px;
+  }
+
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 28px;
+  }
 `;
 
 export const ActivitiesDescription = styled.div`
@@ -158,6 +268,14 @@ export const ActivitiesDescription = styled.div`
   font-weight: 500;
   letter-spacing: -1px;
   margin: 0 0 80px 0;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 18px;
+    margin: 0 0 64px 0;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 14px;
+    margin: 0 0 40px 0;
+  }
 `;
 
 export const ActivitiesCardWrapper = styled.div`
@@ -167,6 +285,9 @@ export const ActivitiesCardWrapper = styled.div`
   justify-content: center;
   gap: 28px 20px;
   margin: auto;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    gap: 22px 16px;
+  }
 `;
 
 export const CalendarContainer = styled.div`
@@ -181,6 +302,12 @@ export const CalendarTitleWrapper = styled.div`
   justify-content: center;
   margin-top: 113px;
   gap: 16px;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    margin-top: 90px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    margin-top: 56px;
+  }
 `;
 
 export const CalendarTitle = styled.div`
@@ -189,6 +316,13 @@ export const CalendarTitle = styled.div`
   font-size: 32px;
   font-weight: 700;
   letter-spacing: -1.6px;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 28px;
+  }
+
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 24px;
+  }
 `;
 
 export const CalendarDescription = styled.div`
@@ -198,6 +332,14 @@ export const CalendarDescription = styled.div`
   font-weight: 500;
   letter-spacing: -1px;
   margin-bottom: 40px;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 18px;
+    margin-bottom: 32px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 14px;
+    margin-bottom: 0px;
+  }
 `;
 
 export const CalendarCardWrapper = styled.div`
@@ -215,7 +357,15 @@ export const RegularCalendarCard = styled.div`
   flex-shrink: 0;
   border-radius: 18px;
   background: var(--blue, #3f69ff);
-  margin: 122px 0 0 110px;
+  margin: 138px 0 0 110px;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    width: 297px;
+    margin: 112px 0 0 103px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    width: 178px;
+    margin: 61px 178px 0 0;
+  }
 `;
 
 export const RegularCalendarWrapper = styled.div`
@@ -223,6 +373,14 @@ export const RegularCalendarWrapper = styled.div`
   padding: 20px 0 0 26px;
   align-items: center;
   gap: 12px;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    padding: 18px 0 0 23px;
+    gap: 10px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    padding: 10px 0 0 13px;
+    gap: 6px;
+  }
 `;
 
 export const RegularCalendarDot = styled.div`
@@ -232,6 +390,14 @@ export const RegularCalendarDot = styled.div`
   background-image: url('/images/icons/about_calendar_white_dot.svg');
   background-size: contain;
   background-repeat: no-repeat;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    width: 9px;
+    height: 9px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    width: 5px;
+    height: 5px;
+  }
 `;
 
 export const RegularCalendarName = styled.h3`
@@ -241,6 +407,12 @@ export const RegularCalendarName = styled.h3`
   font-weight: 600;
   letter-spacing: -1px;
   margin: 0;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 18px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 14px;
+  }
 `;
 
 export const RegularScheduleWrapper = styled.div`
@@ -248,6 +420,12 @@ export const RegularScheduleWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
   gap: 8px 9px;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    padding: 12px 22px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    gap: 4px 5px;
+  }
 `;
 
 export const RegularSchedule = styled.div`
@@ -264,6 +442,14 @@ export const RegularSchedule = styled.div`
   font-weight: 600;
   letter-spacing: -0.7px;
   word-wrap: break-word;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 12px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    font-size: 10px;
+    height: 12px;
+    padding: 5px 10px;
+  }
 `;
 
 export const TeamContainer = styled.div`

--- a/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
+++ b/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
@@ -23,6 +23,7 @@ export const Top = styled.div`
   background-color: #3f69ff;
   justify-content: center;
   display: flex;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     height: 187px;
   }
@@ -39,6 +40,7 @@ export const PageTitleWrapper = styled.div`
   justify-content: center;
   position: absolute;
   z-index: 2;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     margin-top: 53px;
     height: 78px;
@@ -55,6 +57,7 @@ export const PageTitle = styled.h1`
   font-weight: 700;
   letter-spacing: -3.2px;
   margin: -6px 9px;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     font-size: 45px;
   }
@@ -70,6 +73,7 @@ export const PageSubTitle = styled.h1`
   letter-spacing: -1px;
   position: absolute;
   padding: 75px 0 0 117px;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     font-size: 18px;
     padding: 60px 0 0 94px;
@@ -87,6 +91,7 @@ export const IconTitle = styled.div`
   background-size: contain;
   background-repeat: no-repeat;
   margin-top: 5px;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     width: 108px;
     height: 75px;
@@ -113,6 +118,7 @@ export const StyledSquareWrapper = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     height: 40px;
     width: 1000px;
@@ -126,10 +132,10 @@ export const StyledSquareWrapper = styled.div`
 export const StyledSquares = styled.div`
   display: flex;
   height: 50px;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     height: 40px;
   }
-
   @media (max-width: ${BREAKPOINTS[0]}px) {
     height: 25px;
   }
@@ -140,12 +146,12 @@ export const StyledSquare = styled.div`
   height: 50px;
   border-radius: 12px;
   background: ${(props) => props.color || ''};
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     width: 40px;
     height: 40px;
     border-radius: 10px;
   }
-
   @media (max-width: ${BREAKPOINTS[0]}px) {
     width: 25px;
     height: 25px;
@@ -158,12 +164,12 @@ export const StyledSquare2 = styled.div`
   height: 34px;
   border-radius: 12px;
   background: #2051ff;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     width: 40px;
     height: 27px;
     border-radius: 10px;
   }
-
   @media (max-width: ${BREAKPOINTS[0]}px) {
     width: 25px;
     height: 17px;
@@ -180,6 +186,7 @@ export const IntroAPPSTitle = styled.h2`
   line-height: 28px;
   letter-spacing: -1.2px;
   margin: 45px 0 31px 0;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     font-size: 22px;
     margin: 36px 0 25px 0;
@@ -198,6 +205,7 @@ export const IntroAPPSContent = styled.p`
   line-height: 28px;
   letter-spacing: -1px;
   margin: 0 0 53px 0;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     font-size: 18px;
     margin: 0 0 42px 0;
@@ -216,6 +224,7 @@ export const IntroToActLine = styled.div`
   background-size: 962px 2px;
   background-position: center;
   background-repeat: no-repeat;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     background-size: 600px 1px;
   }
@@ -236,6 +245,7 @@ export const ActivitiesTitleWrapper = styled.div`
   justify-content: center;
   margin-top: 113px;
   gap: 16px;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     margin-top: 90px;
   }
@@ -252,6 +262,7 @@ export const ActivitiesTitle = styled.div`
   font-weight: 700;
   line-height: 28px;
   letter-spacing: -2px;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     font-size: 32px;
   }
@@ -268,6 +279,7 @@ export const ActivitiesDescription = styled.div`
   font-weight: 500;
   letter-spacing: -1px;
   margin: 0 0 80px 0;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     font-size: 18px;
     margin: 0 0 64px 0;
@@ -285,6 +297,7 @@ export const ActivitiesCardWrapper = styled.div`
   justify-content: center;
   gap: 28px 20px;
   margin: auto;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     gap: 22px 16px;
   }
@@ -302,6 +315,7 @@ export const CalendarTitleWrapper = styled.div`
   justify-content: center;
   margin-top: 113px;
   gap: 16px;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     margin-top: 90px;
   }
@@ -316,6 +330,7 @@ export const CalendarTitle = styled.div`
   font-size: 32px;
   font-weight: 700;
   letter-spacing: -1.6px;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     font-size: 28px;
   }
@@ -332,6 +347,7 @@ export const CalendarDescription = styled.div`
   font-weight: 500;
   letter-spacing: -1px;
   margin-bottom: 40px;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     font-size: 18px;
     margin-bottom: 32px;
@@ -358,6 +374,7 @@ export const RegularCalendarCard = styled.div`
   border-radius: 18px;
   background: var(--blue, #3f69ff);
   margin: 138px 0 0 110px;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     width: 297px;
     margin: 112px 0 0 103px;
@@ -373,6 +390,7 @@ export const RegularCalendarWrapper = styled.div`
   padding: 20px 0 0 26px;
   align-items: center;
   gap: 12px;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     padding: 18px 0 0 23px;
     gap: 10px;
@@ -390,6 +408,7 @@ export const RegularCalendarDot = styled.div`
   background-image: url('/images/icons/about_calendar_white_dot.svg');
   background-size: contain;
   background-repeat: no-repeat;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     width: 9px;
     height: 9px;
@@ -407,6 +426,7 @@ export const RegularCalendarName = styled.h3`
   font-weight: 600;
   letter-spacing: -1px;
   margin: 0;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     font-size: 18px;
   }
@@ -420,6 +440,7 @@ export const RegularScheduleWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
   gap: 8px 9px;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     padding: 12px 22px;
   }
@@ -442,6 +463,7 @@ export const RegularSchedule = styled.div`
   font-weight: 600;
   letter-spacing: -0.7px;
   word-wrap: break-word;
+
   @media (max-width: ${BREAKPOINTS[1]}px) {
     font-size: 12px;
   }

--- a/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
+++ b/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
@@ -266,7 +266,6 @@ export const ActivitiesTitle = styled.div`
   @media (max-width: ${BREAKPOINTS[1]}px) {
     font-size: 32px;
   }
-
   @media (max-width: ${BREAKPOINTS[0]}px) {
     font-size: 28px;
   }


### PR DESCRIPTION
## 📬 관련 이슈

close #70

<br />

## 🚀 작업 내용

- About 페이지 상단, 활동, 달력 섹션 반응형 구현

<br />

## 📸 스크린샷

|    About 페이지 반응형 구현     |
| :----------------------: |
| <img width='600' src=''> |

<br />

<!-- (선택)
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
