### PR TITLE
#104 [FEAT] 앱스 핵심 코어 영역 해시태그 줄바꿈 적용

### DIFF
--- a/src/components/AboutAppsCoreValueCard/AboutAppsCoreValueCard.jsx
+++ b/src/components/AboutAppsCoreValueCard/AboutAppsCoreValueCard.jsx
@@ -4,6 +4,7 @@ export default function AboutAppsCoreValueCard({
   imageSrc,
   title,
   description,
+  keywords,
   color,
 }) {
   return (
@@ -13,6 +14,11 @@ export default function AboutAppsCoreValueCard({
       </S.ImageWrapper>
       <S.Title color={color}>{title}</S.Title>
       <S.Description color={color}>{description}</S.Description>
+      <S.Description color={color}>
+        {keywords.map((keyword, index) => (
+          <S.Hashtag key={index}>{keyword}&nbsp;</S.Hashtag>
+        ))}
+      </S.Description>
     </S.AboutAppsCoreValueCard>
   );
 }

--- a/src/components/AboutAppsCoreValueCard/AboutAppsCoreValueCard.style.jsx
+++ b/src/components/AboutAppsCoreValueCard/AboutAppsCoreValueCard.style.jsx
@@ -44,5 +44,11 @@ export const Description = styled.p`
   font-size: 14px;
   font-weight: 500;
   letter-spacing: -0.7px;
-  white-space: pre-line;
+  word-break: keep-all;
+  line-height: 1.2;
+`;
+
+export const Hashtag = styled.span`
+  white-space: nowrap;
+  display: inline-block;
 `;

--- a/src/database/appsCoreValueCards.js
+++ b/src/database/appsCoreValueCards.js
@@ -2,29 +2,29 @@ export const APPS_CORE_VALUE_CARDS = [
   {
     imageSrc: '/images/icons/icon-with-A.svg',
     title: '탐구',
-    description:
-      '다양한 분야와 주제에 대한 탐색\n#DevTalk #스터디 #컨퍼런스참여',
+    description: '다양한 분야와 주제에 대한 탐색',
+    keywords: ['#DevTalk', '#스터디', '#컨퍼런스참여'],
     color: '#FF88FB',
   },
   {
     imageSrc: '/images/icons/icon-with-P-green.svg',
     title: '도전',
-    description:
-      '개발자가 되기 위한 끝없는 도전\n#신입부원 웹 프로젝트 #서브스터디',
+    description: '개발자가 되기 위한 끝없는 도전',
+    keywords: ['#신입부원 웹 프로젝트', '#서브스터디'],
     color: '#5BFB67',
   },
   {
     imageSrc: '/images/icons/icon-with-P-orange.svg',
     title: '성장',
-    description:
-      '스터디와 프로젝트를 통한 개발 실력 향상\n#스터디 #프로젝트 #대외활동',
+    description: '스터디와 프로젝트를 통한 개발 실력 향상',
+    keywords: ['#스터디', '#프로젝트', '#대외활동'],
     color: '#FF5400',
   },
   {
     imageSrc: '/images/icons/icon-with-S.svg',
     title: '네트워킹',
-    description:
-      '기수간 꾸준한 소통 및 정보 공유\n#정기세미나 #멘토링 #친목활동',
+    description: '기수간 꾸준한 소통 및 정보 공유',
+    keywords: ['#정기세미나', '#멘토링', '#친목활동'],
     color: '#3F69FF',
   },
 ];

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -54,6 +54,7 @@ export default function HomePage() {
                       imageSrc={card.imageSrc}
                       title={card.title}
                       description={card.description}
+                      keywords={card.keywords}
                       color={card.color}
                     />
                   ))}
@@ -67,6 +68,7 @@ export default function HomePage() {
                       imageSrc={card.imageSrc}
                       title={card.title}
                       description={card.description}
+                      keywords={card.keywords}
                       color={card.color}
                     />
                   ))}


### PR DESCRIPTION
## 📬 관련 이슈

close #104

<br />

## 🚀 작업 내용

- 앱스 핵심 코어 영역 해시태그 줄바꿈 적용

<br />

## 📸 스크린샷

|    `앱스 핵심 코어 영역`     |
| :----------------------: |
| <img width='400' src='https://github.com/user-attachments/assets/fa84b0be-2c56-4f77-8754-c53fb049d0f8'> |

<br />

## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?
배열과 map함수로 수정하면서 길이가 길어졌지만.. 당장은 최선이였습니다..
어떤 이유에서인지 #(샾)과 글자 사이에 띄어쓰기가 없어도 
한단어로 취급을 안하고 계속 줄바꿈이 되더라고요.
여러시도 끝에 찾은 해결 방법입니다^^..

<br />

