### PR TITLE
#111 [FIX] 활동 카드 내 글자 넘침 이슈와 APPS 상단에 파란 블록 화면에 고정되는 이슈 해결

### DIFF
--- a/src/components/ActivityCard/ActivityCard.jsx
+++ b/src/components/ActivityCard/ActivityCard.jsx
@@ -28,18 +28,10 @@ export default function ActivityCard({
       }}
     >
       <S.ActivityBackBlur>
-        <S.ActivityTextWrapper>
-          <S.ActivityNameWrapper>
-            <S.ActivityName>{activityName}</S.ActivityName>
-          </S.ActivityNameWrapper>
-          <S.ActivityIntroWrapper>
-            {isHovering ? (
-              <S.ActivityIntro>{activityIntro}</S.ActivityIntro>
-            ) : (
-              ''
-            )}
-          </S.ActivityIntroWrapper>
-        </S.ActivityTextWrapper>
+        <S.ActivityNameWrapper>
+          <S.ActivityName>{activityName}</S.ActivityName>
+        </S.ActivityNameWrapper>
+        {isHovering ? <S.ActivityIntro>{activityIntro}</S.ActivityIntro> : ''}
       </S.ActivityBackBlur>
     </S.ActivityCard>
   );

--- a/src/components/ActivityCard/ActivityCard.style.jsx
+++ b/src/components/ActivityCard/ActivityCard.style.jsx
@@ -2,8 +2,10 @@ import styled from 'styled-components';
 import { BREAKPOINTS } from '../../styles/mediaQueries.style';
 
 export const ActivityCard = styled.div`
+  display: flex;
   width: 100%;
   max-width: 470px;
+  height: 100%;
   aspect-ratio: 47/30;
   flex-shrink: 0;
   border-radius: 20px;
@@ -12,11 +14,25 @@ export const ActivityCard = styled.div`
   background-repeat: no-repeat;
 `;
 
-export const ActivityTextWrapper = styled.div`
+export const ActivityBackBlur = styled.div`
   display: flex;
   flex-direction: column;
-  height: 80%;
+  justify-content: space-between;
+  flex-shrink: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 20px;
   padding: 30px;
+
+  transition:
+    box-shadow 0.5s ease,
+    background 0.5s ease;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(15px);
+    box-shadow: 0 0 0 1px #fff;
+  }
 
   @media (max-width: ${BREAKPOINTS[1]}px) {
     padding: 24px;
@@ -26,19 +42,22 @@ export const ActivityTextWrapper = styled.div`
   }
 `;
 
-export const ActivityNameWrapper = styled.div``;
+export const ActivityNameWrapper = styled.div`
+  display: flex;
+  justify-content: flex-start;
+`;
 
 export const ActivityName = styled.h2`
   margin: 0;
-  display: inline-flex;
-  padding: 13px 43px;
+  display: flex;
   justify-content: center;
   align-items: center;
+  text-align: center;
+  padding: 13px 43px;
   gap: 10px;
   border-radius: 30px;
   background: var(--orange, #ff5400);
   color: #fff;
-  text-align: center;
   font-size: 20px;
   font-weight: 600;
   letter-spacing: -1px;
@@ -52,38 +71,15 @@ export const ActivityName = styled.h2`
   }
 `;
 
-export const ActivityIntroWrapper = styled.div`
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: end;
-`;
-
 export const ActivityIntro = styled.p`
+  margin: 0;
   color: #fff;
   font-size: 16px;
   letter-spacing: -0.7px;
-  margin: 0;
   word-break: keep-all;
+  line-height: 1.2;
 
   @media (max-width: ${BREAKPOINTS[0]}px) {
-    font-size: 12px;
-  }
-`;
-
-export const ActivityBackBlur = styled.div`
-  flex-shrink: 0;
-  width: 100%;
-  height: 100%;
-  border-radius: 20px;
-
-  transition:
-    box-shadow 0.5s ease,
-    background 0.5s ease;
-
-  &:hover {
-    background: rgba(0, 0, 0, 0.5);
-    backdrop-filter: blur(15px);
-    box-shadow: 0 0 0 1px #fff;
+    font-size: 14px;
   }
 `;

--- a/src/styles/exhibitionStyles.style.js
+++ b/src/styles/exhibitionStyles.style.js
@@ -14,7 +14,6 @@ export const exhibitionStyles = css`
   }
 
   body {
-    height: 100%;
     -ms-overflow-style: none;
     overflow-x: hidden;
   }


### PR DESCRIPTION
## 📬 관련 이슈

close #111

<br />

## 🚀 작업 내용

- 활동 카드 내 글자 넘침 이슈 해결
- APPS 상단에 파란 블록 화면에 고정되는 이슈 해결

참고: ActivityCard 컴포넌트 내에 구성되어 있는 컴포넌트를 최소화하였고,
컴포넌트 내 제목과 설명글을 포괄하는 컴포넌트에 아래와 같은 속성을 적용하였습니다.
Card컴포넌트의 크기 상관없이 글자는 하단에 위치하게 될 예정입니다.

```CSS
  display: flex; // 요소들 가로 정렬
  flex-direction: column; // 가로정렬을 세로정렬로 바꿔줌
  justify-content: space-between; // 간격을 벌려줌
```

<br />

## 📸 스크린샷

|  반응형   |
| :----------------------: |
| <img width='400' src='https://github.com/user-attachments/assets/b299b8a4-b105-4bcf-8ebb-0ed44d60ecc9'> |

<br />

