### PR TITLE
#116 [FIX] SNS 이미지 가운데 정렬

### DIFF
--- a/src/components/SocialMediaLinkCards/SocialMediaLinkCards.style.jsx
+++ b/src/components/SocialMediaLinkCards/SocialMediaLinkCards.style.jsx
@@ -16,6 +16,7 @@ export const SocialLinksCard = styled.div`
 
 export const SocialLinksCardImage = styled.div`
   display: flex;
+  justify-content: center;
   height: 90px;
 
   @media (max-width: ${BREAKPOINTS[0]}px) {


### PR DESCRIPTION
## 📬 관련 이슈

close #116

<br />

## 🚀 작업 내용

- SNS 이미지 가운데 정렬 (웹페이지 내에서는 동일함. but 배포된 사이트에서 좌측정렬 되어 있음)