### PR TITLE
#119 [FEAT] About 페이지 `ActivityCard` 배치 변경

### DIFF
--- a/src/components/ActivityCard/ActivityCard.style.jsx
+++ b/src/components/ActivityCard/ActivityCard.style.jsx
@@ -35,10 +35,7 @@ export const ActivityBackBlur = styled.div`
   }
 
   @media (max-width: ${BREAKPOINTS[1]}px) {
-    padding: 24px;
-  }
-  @media (max-width: ${BREAKPOINTS[0]}px) {
-    padding: 16px;
+    padding: 20px;
   }
 `;
 
@@ -63,11 +60,8 @@ export const ActivityName = styled.h2`
   letter-spacing: -1px;
 
   @media (max-width: ${BREAKPOINTS[1]}px) {
-    padding: 10px 32px;
-  }
-  @media (max-width: ${BREAKPOINTS[0]}px) {
-    font-size: 14px;
-    padding: 8px 24px;
+    font-size: 16px;
+    padding: 10px 36px;
   }
 `;
 
@@ -79,7 +73,7 @@ export const ActivityIntro = styled.p`
   word-break: keep-all;
   line-height: 1.2;
 
-  @media (max-width: ${BREAKPOINTS[0]}px) {
-    font-size: 14px;
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    font-size: 12px;
   }
 `;

--- a/src/components/FallingBlocks/FallingBlocks.jsx
+++ b/src/components/FallingBlocks/FallingBlocks.jsx
@@ -30,7 +30,7 @@ export default function FallingBlocks({ delay, fromY, toY, time, colors }) {
   }, [isFalling, toY, time]);
 
   return (
-    <S.FallingBlocksLine yPos={yPos}>
+    <S.FallingBlocksLine ypos={yPos}>
       {colors.map((left, leftIndex) => (
         <S.StyledSquares key={leftIndex}>
           {left.map((c, cIndex) => (

--- a/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
+++ b/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
@@ -241,8 +241,9 @@ export const ActivitiesDescription = styled.div`
 `;
 
 export const ActivitiesCardWrapper = styled.div`
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  justify-items: center;
   justify-content: center;
   width: 100%;
   max-width: 960px;
@@ -251,6 +252,9 @@ export const ActivitiesCardWrapper = styled.div`
 
   @media (max-width: ${BREAKPOINTS[1]}px) {
     gap: 22px 16px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    grid-template-columns: repeat(1, 1fr);
   }
 `;
 

--- a/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
+++ b/src/pages/AboutAppsPage/AboutAppsPage.style.jsx
@@ -55,6 +55,7 @@ export const PageTitleWrapper = styled.div`
 
 export const PageTitle = styled.h1`
   color: #fff;
+  font-family: 'Dolce Vita Heavy';
   font-size: 65px;
   font-weight: 700;
   letter-spacing: -3.2px;
@@ -92,7 +93,7 @@ export const IconTitle = styled.div`
   background-image: url('./images/icons/about_APPS.svg');
   background-size: contain;
   background-repeat: no-repeat;
-  margin-top: 5px;
+  margin-top: -5px;
 
   @media (max-width: ${BREAKPOINTS[1]}px) {
     width: 108px;


### PR DESCRIPTION
## 📬 관련 이슈

close #119

<br />

## 🚀 작업 내용

- About 페이지 상단 폰트 적용 및 배치 수정
- `ActivityCard` 배치 반응형 변경
- `yPos` 오류 해결

<br />

## 📸 스크린샷

|    About 페이지 `ActivityCard` 배치 반응형 변경     |
| :----------------------: |
| <img width='600' src='https://github.com/user-attachments/assets/86b9c2d3-0743-4381-a52a-2bbf0f918cee'> |

<br />

<!-- (선택)
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
