### PR TITLE
#144 [FEAT] 프로젝트 페이지 하단 여백 제거 및 링크 버튼 수정

### DIFF
--- a/src/pages/ProjectPage/ProjectPage.jsx
+++ b/src/pages/ProjectPage/ProjectPage.jsx
@@ -20,8 +20,6 @@ export default function ProjectPage() {
     ));
   };
 
-  const YoutubeLink = 'https://www.youtube.com/watch?v=';
-
   return (
     <S.Root>
       <S.Container>
@@ -38,58 +36,66 @@ export default function ProjectPage() {
               <S.ShareText>프로젝트 공유하기</S.ShareText>
             </S.ShareBtn>
             <S.LinkBtns>
-              <a
-                href={projectData.githubUrls.clientUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <S.LinkBtn>
-                  <S.LinkIcon
-                    src="../../images/socials/github.svg"
-                    alt="github"
-                  />
-                  <p>Client</p>
-                </S.LinkBtn>
-              </a>
-              <a
-                href={projectData.githubUrls.serverUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <S.LinkBtn>
-                  <S.LinkIcon
-                    src="../../images/socials/github.svg"
-                    alt="github"
-                  />
-                  <p>Server</p>
-                </S.LinkBtn>
-              </a>
-              <a
-                href={YoutubeLink + projectData.youtubeVideoId}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <S.LinkBtn>
-                  <S.LinkIcon
-                    src="../../images/socials/webpage-link.svg"
-                    alt="link"
-                  />
-                  <p>Youtube</p>
-                </S.LinkBtn>
-              </a>
-              <a
-                href="https://appstore.com"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <S.LinkBtn>
-                  <S.LinkIcon
-                    src="../../images/socials/app-store.svg"
-                    alt="appstore"
-                  />
-                  <p>AppStore</p>
-                </S.LinkBtn>
-              </a>
+              {projectData.githubUrls.clientUrl && (
+                <a
+                  href={projectData.githubUrls.clientUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <S.LinkBtn>
+                    <S.LinkIcon
+                      src="../../images/socials/github.svg"
+                      alt="github"
+                    />
+                    <p>Client</p>
+                  </S.LinkBtn>
+                </a>
+              )}
+              {projectData.githubUrls.serverUrl && (
+                <a
+                  href={projectData.githubUrls.serverUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <S.LinkBtn>
+                    <S.LinkIcon
+                      src="../../images/socials/github.svg"
+                      alt="github"
+                    />
+                    <p>Server</p>
+                  </S.LinkBtn>
+                </a>
+              )}
+              {projectData.webpageLinkUrl && (
+                <a
+                  href={projectData.webpageLinkUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <S.LinkBtn>
+                    <S.LinkIcon
+                      src="../../images/socials/webpage-link.svg"
+                      alt="link"
+                    />
+                    <p>Link</p>
+                  </S.LinkBtn>
+                </a>
+              )}
+              {projectData.downloadLinkUrl && (
+                <a
+                  href={projectData.downloadLinkUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <S.LinkBtn>
+                    <S.LinkIcon
+                      src="../../images/socials/app-store.svg"
+                      alt="appstore"
+                    />
+                    <p>AppStore</p>
+                  </S.LinkBtn>
+                </a>
+              )}
             </S.LinkBtns>
           </S.TopBtnContainer>
           <S.YoutubeContainer>

--- a/src/pages/ProjectPage/ProjectPage.style.jsx
+++ b/src/pages/ProjectPage/ProjectPage.style.jsx
@@ -3,11 +3,12 @@ import { BREAKPOINTS } from '../../styles/mediaQueries.style';
 
 export const Root = styled.div`
   width: 100%;
-  min-height: 5000px;
+  height: fit-content;
   background-image: url('/images/background/projects_background.svg');
   background-size: contain;
   background-repeat: no-repeat;
   background-color: #000;
+  padding-bottom: 120px;
 `;
 
 export const Container = styled.div`


### PR DESCRIPTION
## 📬 관련 이슈

close #144

<br />

## 🚀 작업 내용

- 프로젝트 페이지 하단 여백 제거 및 링크 버튼 수정

<br />

## 📸 스크린샷

|    프로젝트 페이지 하단 여백 제거 및 링크 버튼 수정     |
| :----------------------: |
| <img width='600' src='https://github.com/user-attachments/assets/06347c93-5a72-4242-b272-dd7dde986be3'> |

<br />

<!-- (선택)
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
