### PR TITLE
#160 [FEAT] 페이지 이동 시 맨 위로 위치하기 구현

### DIFF
--- a/src/components/ScrollToTop/ScrollToTop.jsx
+++ b/src/components/ScrollToTop/ScrollToTop.jsx
@@ -1,0 +1,14 @@
+import React, { useEffect } from 'react';
+import { Outlet, useLocation } from 'react-router-dom';
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return <Outlet />;
+};
+
+export default ScrollToTop;

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -1,18 +1,24 @@
 import { createBrowserRouter } from 'react-router-dom';
+import ScrollToTop from './components/ScrollToTop/ScrollToTop';
 import { HomePage, AboutAppsPage, ProjectPage } from './pages';
 
 const router = createBrowserRouter([
   {
-    path: '/',
-    element: <HomePage />,
-  },
-  {
-    path: '/about',
-    element: <AboutAppsPage />,
-  },
-  {
-    path: '/projects/:id',
-    element: <ProjectPage />,
+    element: <ScrollToTop />,
+    children: [
+      {
+        path: '/',
+        element: <HomePage />,
+      },
+      {
+        path: '/about',
+        element: <AboutAppsPage />,
+      },
+      {
+        path: '/projects/:id',
+        element: <ProjectPage />,
+      },
+    ],
   },
 ]);
 

--- a/src/styles/exhibitionStyles.style.js
+++ b/src/styles/exhibitionStyles.style.js
@@ -10,7 +10,6 @@ export const exhibitionStyles = css`
     height: 100%;
     overflow-x: hidden;
     overflow-y: auto;
-    scroll-behavior: smooth;
   }
 
   body {


### PR DESCRIPTION
## 📬 관련 이슈

close #160

<br />

## 🚀 작업 내용

- 페이지 이동 시 맨 위로 위치하기 구현

<br />

## 📸 스크린샷

|    페이지 이동 시 맨 위로 위치하기 구현     |
| :----------------------: |
| <img width='600' src='https://github.com/user-attachments/assets/33748622-5e91-4fa5-b1c0-e3da69e18451'> |

<br />

<!-- (선택)
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
