### PR TITLE
#191 [FIX] Safari에서 프로젝트 카드 비율 깨짐 오류 해결

### DIFF
--- a/src/components/ProjectCardList/ProjectCardList.style.jsx
+++ b/src/components/ProjectCardList/ProjectCardList.style.jsx
@@ -68,12 +68,14 @@ export const ProjectCardContainer = styled.div`
 
 export const ProjectCardImage = styled.div`
   width: 100%;
-  aspect-ratio: 16 / 9;
+  height: auto;
   border-radius: 20px;
   overflow: hidden;
 
   img {
+    display: block;
     width: 100%;
+    height: auto;
     object-fit: cover;
   }
 `;


### PR DESCRIPTION
## 📬 관련 이슈

close #191

<br />

## 🚀 작업 내용

-  Safari에서 프로젝트 카드 비율 깨짐 오류 해결

<br />

## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?
- Safari가 'aspect-ratio' 속성을 인식 못해서 생기는 오류
- 'aspect-ratio' 속성 다른 거로 대체해서 해결.


<br />
